### PR TITLE
Update component style to 'new-york' in components.json

### DIFF
--- a/components.json
+++ b/components.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://shadcn-vue.com/schema.json",
-  "style": "default",
+  "style": "new-york",
   "typescript": true,
   "tailwind": {
     "config": "tailwind.config.js",


### PR DESCRIPTION
This pull request includes a change to the `components.json` file to update the style configuration.

Configuration update:

* [`components.json`](diffhunk://#diff-2c9eb56f775dd960fa3fb60253b2d30f21baae2e81f352e63a0984f129408016L3-R3): Changed the `style` property from "default" to "new-york".